### PR TITLE
File Button and Public Resultstore Redirect

### DIFF
--- a/e2e/cypress/integration/app.spec.ts
+++ b/e2e/cypress/integration/app.spec.ts
@@ -33,21 +33,23 @@ context("ResultStoreSearch Home Page", () => {
   });
 
   it("Should display tooltip on hover", () => {
-    cy.get('svg[aria-label="SearchHelp"').trigger("mouseover");
+    cy.get('svg[aria-label="SearchHelp"]').trigger("mouseover");
     cy.get('div[class="MuiTooltip-popper"]').contains(
       'Fields that support equals ("=") restrictions:'
     );
   });
 
-  it("Should open the file modal on row click", () => {
+  it("Should open the file modal on file button click", () => {
     cy.get('input[id="outlined-adornment-amount"]').type("a");
-    cy.get('div[aria-rowindex="1"]').click();
+    cy.get('div[aria-rowindex="1"]').trigger("mouseover");
+    cy.get('button[id="FileButton-0"]').click();
     cy.get('div[id="FileModal"]').should("have.length", 1);
   });
 
   it("Should render files in the file table", () => {
     cy.get('input[id="outlined-adornment-amount"]').type("a");
-    cy.get('div[aria-rowindex="1"]').click();
+    cy.get('div[aria-rowindex="1"]').trigger("mouseover");
+    cy.get('button[id="FileButton-0"]').click();
     cy.get('div[id="InvocationModalRow"]').click();
     cy.get('div[id="FileTable"]').contains("test-file");
   });

--- a/resultstore-search-api/credentials.py
+++ b/resultstore-search-api/credentials.py
@@ -23,6 +23,7 @@ class Credentials():
     """
     Credentials container/helper for resultstoreui
     """
+
     def __init__(self):
         """
         Initialize Credentials

--- a/resultstore-search-client/src/components/InfiniteTable/BaseTable/index.tsx
+++ b/resultstore-search-client/src/components/InfiniteTable/BaseTable/index.tsx
@@ -28,6 +28,8 @@ export type Props = SelfProps &
         | 'rowGetter'
         | 'rowClassName'
         | 'onRowClick'
+        | 'onRowMouseOver'
+        | 'onRowMouseOut'
     > &
     InfiniteLoaderChildProps;
 
@@ -56,6 +58,8 @@ const BaseTable: React.FC<Props> = ({
     headerClass,
     cellClass,
     gridClass,
+    onRowMouseOut,
+    onRowMouseOver,
 }) => {
     const classes = useStyles();
 
@@ -103,6 +107,8 @@ const BaseTable: React.FC<Props> = ({
             rowGetter={rowGetter}
             rowCount={rowCount}
             onRowClick={onRowClick}
+            onRowMouseOut={onRowMouseOut}
+            onRowMouseOver={onRowMouseOver}
         >
             {columns.map(({ dataKey, width, ...other }) => {
                 return (

--- a/resultstore-search-client/src/components/InfiniteTable/index.tsx
+++ b/resultstore-search-client/src/components/InfiniteTable/index.tsx
@@ -19,6 +19,8 @@ const InfiniteTable: React.FC<Props> = ({
     headerClass,
     cellClass,
     gridClass,
+    onRowMouseOver,
+    onRowMouseOut,
 }) => {
     return (
         <InfiniteLoader
@@ -43,6 +45,8 @@ const InfiniteTable: React.FC<Props> = ({
                     cellClass={cellClass}
                     headerClass={headerClass}
                     gridClass={gridClass}
+                    onRowMouseOver={onRowMouseOver}
+                    onRowMouseOut={onRowMouseOut}
                 />
             )}
         </InfiniteLoader>

--- a/resultstore-search-client/src/components/InvocationTable/types.ts
+++ b/resultstore-search-client/src/components/InvocationTable/types.ts
@@ -29,3 +29,12 @@ export interface ModalState {
     isOpen: boolean;
     index: number;
 }
+
+export interface FileButtonProps {
+    isVisible: boolean;
+}
+
+export interface HoverState {
+    isHovered: boolean;
+    rowIndex: number;
+}

--- a/resultstore-search-client/src/components/SearchWrapper/ToolSelect/index.tsx
+++ b/resultstore-search-client/src/components/SearchWrapper/ToolSelect/index.tsx
@@ -23,8 +23,8 @@ const useStyles = makeStyles((theme: Theme) =>
 );
 
 const createToolItems = (toolsList: ToolSelectProps['toolsList']) => {
-    return toolsList.map((tool) => (
-        <MenuItem value={tool}>
+    return toolsList.map((tool, index) => (
+        <MenuItem value={tool} key={index}>
             <em>{tool}</em>
         </MenuItem>
     ));


### PR DESCRIPTION
Adds File Button to open File Modal instead of row click.
Row click now opens public resultstore page.
PR is blocked by https://github.com/google/resultstoreui/pull/39
![FileButton](https://user-images.githubusercontent.com/22064715/87317902-9f7ca880-c4f5-11ea-9cc3-e3ea7653caab.gif)
